### PR TITLE
Prevent select_version counter from triggering script exit

### DIFF
--- a/start_minecraft.sh
+++ b/start_minecraft.sh
@@ -312,7 +312,7 @@ select_version_for_type() {
     local count=0
     for v in "${all_versions[@]}"; do
         menu_versions+=("$v")
-        ((count++))
+        ((++count))
         if ((count >= limit)); then
             break
         fi
@@ -1066,7 +1066,7 @@ restore_backup() {
     (
         local count=0
         while IFS= read -r _; do
-            ((count++))
+            ((++count))
             printf '%s\n' "$count" > "$count_file"
         done < "$fifo"
     ) &


### PR DESCRIPTION
## Summary
- ensure the version selection menu increments its counter without triggering set -e
- update the restore progress counter to avoid non-zero exit statuses under set -e

## Testing
- PATH=$PWD/stubs:$PATH bash start_minecraft.sh (manually exited after verifying menus)


------
https://chatgpt.com/codex/tasks/task_e_68dfd02e3eb4832191afe0f6ac77b3c3