### PR TITLE
Allow custom version selection and prompt for container name

### DIFF
--- a/start_minecraft.sh
+++ b/start_minecraft.sh
@@ -399,6 +399,15 @@ select_version_for_type() {
             return
         fi
 
+        local confirm_custom
+        confirm_custom=$(read_yesno_with_history "Die Auswahl '${chosen}' konnte nicht geprüft werden. Trotzdem verwenden?" "CONFIRM_VERSION_${type^^}")
+        if [[ "${confirm_custom,,}" == "ja" ]]; then
+            save_history "$history_key" "$chosen"
+            VERSION="$chosen"
+            log "Hinweis: Verwende benutzerdefinierte Version '${chosen}' ohne Validierung."
+            return
+        fi
+
         echo "Die Auswahl '${chosen}' ist nicht unter den verfügbaren Versionen. Bitte erneut wählen." >&2
     done
 }
@@ -440,6 +449,7 @@ DATA_DIR=$(read_with_history "Pfad zum Minecraft-Datenverzeichnis" "/opt/minecra
 
 # === Initialisierung nach DATA_DIR ===
 SERVER_NAME="mc"
+SERVER_NAME=$(read_with_history "Docker Container-Name" "$SERVER_NAME" "SERVER_NAME")
 BACKUP_DIR="${DATA_DIR}/backups"
 PLUGIN_DIR="${DATA_DIR}/plugins"
 PLUGIN_CONFIG="${DATA_DIR}/plugins.txt"


### PR DESCRIPTION
## Summary
- allow users to confirm and use custom Minecraft versions that are not returned by the API, logging the choice
- prompt for the Docker container name so multiple servers can run with unique identifiers

## Testing
- bash -n start_minecraft.sh

------
https://chatgpt.com/codex/tasks/task_e_68dfdfc82b0c8321abf16fae3f66d21d